### PR TITLE
solved the // bug

### DIFF
--- a/backend/Functions/Edna.Connect/Lti1Api.cs
+++ b/backend/Functions/Edna.Connect/Lti1Api.cs
@@ -17,7 +17,7 @@ namespace Edna.Connect
     public class Lti1Api
     {
         private static readonly string ToolSecret = Environment.GetEnvironmentVariable("Lti1Secret");
-        private static readonly string RedirectUrl = Environment.GetEnvironmentVariable("RedirectUrl");
+        private static readonly string RedirectUrl = Environment.GetEnvironmentVariable("RedirectUrl").TrimEnd('/');
 
         private readonly ILogger<Lti1Api> _logger;
 

--- a/backend/Functions/Edna.Connect/LtiAdvantageApi.cs
+++ b/backend/Functions/Edna.Connect/LtiAdvantageApi.cs
@@ -22,7 +22,7 @@ namespace Edna.Connect
 {
     public class LtiAdvantageApi
     {
-        private static readonly string RedirectUrl = Environment.GetEnvironmentVariable("RedirectUrl");
+        private static readonly string RedirectUrl = Environment.GetEnvironmentVariable("RedirectUrl").TrimEnd('/');
 
         private readonly ILogger<LtiAdvantageApi> _logger;
 

--- a/backend/Functions/Edna.Platforms/Edna.Platforms/PlatformsApi.cs
+++ b/backend/Functions/Edna.Platforms/Edna.Platforms/PlatformsApi.cs
@@ -22,7 +22,7 @@ namespace Edna.Platforms
     public class PlatformsApi
     {
         private const string PlatformsTableName = "Platforms";
-        private static readonly string ConnectApiBaseUrl = Environment.GetEnvironmentVariable("ConnectApiBaseUrl");
+        private static readonly string ConnectApiBaseUrl = Environment.GetEnvironmentVariable("ConnectApiBaseUrl").TrimEnd('/');
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
         private static readonly string[] AllowedUsers = Environment.GetEnvironmentVariable("AllowedUsers")?.Split(";") ?? new string[0];
 

--- a/backend/Functions/Edna.Platforms/Edna.Platforms/Profile.cs
+++ b/backend/Functions/Edna.Platforms/Edna.Platforms/Profile.cs
@@ -4,7 +4,7 @@ namespace Edna.Platforms
 {
     public class Profile : AutoMapper.Profile
     {
-        private static readonly string ConnectApiBaseUrl = Environment.GetEnvironmentVariable("ConnectApiBaseUrl");
+        private static readonly string ConnectApiBaseUrl = Environment.GetEnvironmentVariable("ConnectApiBaseUrl").TrimEnd('/');
 
         public Profile()
         {


### PR DESCRIPTION
## User Issue
* User is unable to visit the **Learn-LTI** homepage when clicking an assignment inside the LMS created using **Learn-LTI** Tool.
* Connect Urls presented inside the platform page doesn't work

## RCA
The / was being added at 2 places which was causing the urls to not work and not loading the assignments inside the LMS.

## Solution
Removed one of the 2 '/' in the code.
