### PR TITLE
Fixing Install scripts to be able to run as standalone Scripts / Cmdlets

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -2,9 +2,9 @@ $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $ExecutionStartTime = $(get-date -f dd-MM-yyyy-HH-mm-ss)
 $LogRoot = Join-Path $scriptPath "Log"
 $LogFile = Join-Path $LogRoot "Log-$ExecutionStartTime.log"
-$resourceGroupName = "MSLearnLTI-AB"
-$identityName = "MSLearnLTI-Identity-AB"
-$appName = "MS-Learn-Lti-Tool-App-AB"
+$resourceGroupName = "MSLearnLTI"
+$identityName = "MSLearnLTI-Identity"
+$appName = "MS-Learn-Lti-Tool-App"
 
 function Write-LogInternal {
     param (


### PR DESCRIPTION
## Summary
`Install-Backend` and `Install-Client` fail when executed standalone due to missing `Write-Log` command definition.

## Fix
Introduced a local scope `Write-{}DebugLog` function which invokes `Write-Log` if exists, else call `Write-Verbose` forced.