### PR TITLE
Updating Platforms API to check for all possible EmailClaimTypes when matching AllowedUsers

### DIFF
--- a/backend/Functions/Edna.Platforms/Edna.Platforms/PlatformsApi.cs
+++ b/backend/Functions/Edna.Platforms/Edna.Platforms/PlatformsApi.cs
@@ -22,6 +22,8 @@ namespace Edna.Platforms
     public class PlatformsApi
     {
         private const string PlatformsTableName = "Platforms";
+
+        private static readonly string[] PossibleEmailClaimTypes = { "email", "upn", "unique_name" };
         private static readonly string ConnectApiBaseUrl = Environment.GetEnvironmentVariable("ConnectApiBaseUrl").TrimEnd('/');
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
         private static readonly string[] AllowedUsers = Environment.GetEnvironmentVariable("AllowedUsers")?.Split(";") ?? new string[0];
@@ -142,17 +144,34 @@ namespace Edna.Platforms
 
             if (appidacr == "0")
             {
-                string uniqueName = claims.FirstOrDefault(claim => claim.Type == "unique_name")?.Value;
-                if (string.IsNullOrEmpty(uniqueName))
+                if (!TryGetUserEmails(claims, out List<string> userEmails))
                 {
-                    _logger.LogWarning("There is no unique identifier for the current user.");
+                    _logger.LogError("Could not get any user email / uid for the current user.");
                     return false;
                 }
 
-                return AllowedUsers.Contains(uniqueName);
+                return AllowedUsers.Intersect(userEmails).Any();
             }
 
             return false;
+        }
+
+        private bool TryGetUserEmails(IEnumerable<Claim> claims, out List<string> userEmails)
+        {
+            userEmails = new List<string>();
+            if (claims == null)
+                return false;
+
+            Claim[] claimsArray = claims.ToArray();
+
+            userEmails = PossibleEmailClaimTypes
+                .Select(claimType => claimsArray.FirstOrDefault(claim => claim.Type == claimType))
+                .Where(claim => claim != null)
+                .Select(claim => claim.Value)
+                .Distinct()
+                .ToList();
+
+            return userEmails.Any();
         }
     }
 }


### PR DESCRIPTION
## Issue
The Platform Authentication is Failing for Non-Microsoft Accounts stating the user is unauthorized even when the email is present in the list of `AllowedUsers`.

## RCA
The check is that the Allowed Users currently matches only with `unique_name` claim inside the passed jwt. Since the `unique_name` is different from the email in `AllowedUsers`, the check fails and ends up sending **http403**.

## Fix
* We have modified the check to match against all possible Email claim types, i.e. `unique_name`, `email` & `upn`
> Similar check has already been done by in the _Users_ `/me` api when checking for membership via NRPS.