### PR TITLE
Bugfix/accepting underscore in assignment

### DIFF
--- a/backend/Functions/Edna.Assignments/Edna.Assignments/AssignmentDtoExtensions.cs
+++ b/backend/Functions/Edna.Assignments/Edna.Assignments/AssignmentDtoExtensions.cs
@@ -32,6 +32,5 @@ namespace Edna.Assignments
         }
 
         public static string ToAssignmentId(this ITableEntity entity) => $"{GetEncoded(entity.PartitionKey)}_{GetEncoded(entity.RowKey)}";
-
     }
 }


### PR DESCRIPTION
**ISSUE**
The code also uses an underscore as a delimiter to make assignmentId from ContextId & ResourceLinkId. 
Blackboard is sending the resourceLinkId containing underscores which caused the code to fail.

**RSA**
The code was failing due to multiple underscores, and it couldn't distinguish between the delimiter underscore & value of ContextId & resourceLinkId.

**SOLUTION**
Updates the AssignmentDtoExtensions.cs file so as to encode the values of the ContextId & ResourceLinkId using the Base64 encoding and then forming the assignmentId using these encoded values.