### PR TITLE
Remove building netcore3.1 for LtiAdvantage

### DIFF
--- a/backend/ThirdParty/LtiAdvantage/LtiAdvantage/LtiAdvantage.csproj
+++ b/backend/ThirdParty/LtiAdvantage/LtiAdvantage/LtiAdvantage.csproj
@@ -1,12 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
@@ -15,10 +11,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />


### PR DESCRIPTION
## Summary

As a follow-up to OSS compliance work, we get rid of netcore3.1 compilation in the 3rd party dependencies as these are: - 
1. not used by wrapping Function Bindings yet.
2. not included in upstream [LtiAdvantage](https://github.com/LtiLibrary/LtiAdvantage) repo.

## Testing
- [x] Deploy and register a new LTI with Moodle.
- [x] Create a new assignment using the new tool.
- [x] Test the Tool as a Teacher - Learn Content, Links, Participants, Publish, Description
- [x] Test the Tool as a Student - Learn Content redirection, Links