### PR TITLE
Bugfix/removing trailing slash

### DIFF
--- a/backend/Functions/Edna.Connect/LtiAdvantageApi.cs
+++ b/backend/Functions/Edna.Connect/LtiAdvantageApi.cs
@@ -75,7 +75,17 @@ namespace Edna.Connect
             [DurableClient] IDurableEntityClient entityClient,
             string platformId)
         {
-            LtiResourceLinkRequest ltiResourceLinkRequest = await ltiRequestClient.GetLtiResourceLinkRequest(platform.JwkSetUrl, platform.ClientId, platform.Issuer);
+            LtiResourceLinkRequest ltiResourceLinkRequest = null;
+            try
+            {
+                ltiResourceLinkRequest= await ltiRequestClient.GetLtiResourceLinkRequest(platform.JwkSetUrl, platform.ClientId, platform.Issuer);
+            }
+            catch(Exception e)
+            {
+                _logger.LogError($"Could not validate request.\n{e}");
+            }
+            if (ltiResourceLinkRequest == null)
+                return new BadRequestErrorMessageResult("Could not validate request.");
 
             string nonce = ltiResourceLinkRequest.Nonce;
             string state = req.Form["state"].ToString();

--- a/backend/Functions/Edna.Platforms/Edna.Platforms/Profile.cs
+++ b/backend/Functions/Edna.Platforms/Edna.Platforms/Profile.cs
@@ -17,10 +17,10 @@ namespace Edna.Platforms
                 .ReverseMap()
                 .ForMember(entity => entity.PartitionKey, expression => expression.MapFrom(dto => dto.Id))
                 .ForMember(entity => entity.RowKey, expression => expression.MapFrom(dto => dto.Id))
-                .ForMember(entity => entity.Issuer, expression => expression.MapFrom(dto => dto.Issuer.Trim().TrimEnd('/')))
-                .ForMember(entity => entity.JwkSetUrl, expression => expression.MapFrom(dto => dto.JwkSetUrl.Trim().TrimEnd('/')))
-                .ForMember(entity => entity.AccessTokenUrl, expression => expression.MapFrom(dto => dto.AccessTokenUrl.Trim().TrimEnd('/')))
-                .ForMember(entity => entity.AuthorizationUrl, expression => expression.MapFrom(dto => dto.AuthorizationUrl.Trim().TrimEnd('/')))
+                .ForMember(entity => entity.Issuer, expression => expression.MapFrom(dto => dto.Issuer.Trim()))
+                .ForMember(entity => entity.JwkSetUrl, expression => expression.MapFrom(dto => dto.JwkSetUrl.Trim()))
+                .ForMember(entity => entity.AccessTokenUrl, expression => expression.MapFrom(dto => dto.AccessTokenUrl.Trim()))
+                .ForMember(entity => entity.AuthorizationUrl, expression => expression.MapFrom(dto => dto.AuthorizationUrl.Trim()))
                 .ForMember(entity => entity.ClientId, expression => expression.MapFrom(dto => dto.ClientId.Trim()));
         }
     }


### PR DESCRIPTION
**Issue**
The tool doesn't integrate with the LMS properly if any of the URLs in the Platform Registration page have a trailing slash

**Solution**
trimming the trailing slashes, if any, in the URLs entered in the platform registration page.

### UPDATE  
A better solution to this issue is to show proper error to the user that token validation is failing, so that they can configure the tool properly. This covers a larger number of scenarios as the token validation could fail due to more than 1 reason.