### PR TITLE
Fixing Serialization Issue in JWK

### DIFF
--- a/backend/Functions/Edna.Platforms/Edna.Platforms/PlatformsApi.cs
+++ b/backend/Functions/Edna.Platforms/Edna.Platforms/PlatformsApi.cs
@@ -63,7 +63,7 @@ namespace Edna.Platforms
                     .Select(_mapper.Map<PlatformDto>)
                     .Do(dto => { 
                         dto.PublicKey = publicKey.PemString;
-                        dto.ToolJwk = JsonSerializer.Serialize(publicKey.Jwk);
+                        dto.ToolJwk = Newtonsoft.Json.JsonConvert.SerializeObject(publicKey.Jwk);
                     });
 
                 platforms.AddRange(platformDtos);
@@ -83,7 +83,7 @@ namespace Edna.Platforms
 
             PlatformDto platformDto = _mapper.Map<PlatformDto>(platformEntity);
             platformDto.PublicKey = publicKey.PemString;
-            platformDto.ToolJwk = JsonSerializer.Serialize(publicKey.Jwk);
+            platformDto.ToolJwk = Newtonsoft.Json.JsonConvert.SerializeObject(publicKey.Jwk);
             
             return new OkObjectResult(platformDto);
         }
@@ -104,7 +104,7 @@ namespace Edna.Platforms
                 LoginUrl = $"{ConnectApiBaseUrl}/oidc-login/{platformId}",
                 LaunchUrl = $"{ConnectApiBaseUrl}/lti-advantage-launch/{platformId}",
                 PublicKey = publicKey.PemString,
-                ToolJwk = JsonSerializer.Serialize(publicKey.Jwk),
+                ToolJwk = Newtonsoft.Json.JsonConvert.SerializeObject(publicKey.Jwk),
                 ToolJwkSetUrl = $"{ConnectApiBaseUrl}/jwks/{platformId}",
                 DomainUrl = new Uri(ConnectApiBaseUrl).Authority
             };


### PR DESCRIPTION
## Issue
The property names on the `JWK` were in Camel Case and that was breaking our integration with Canvas. It is also not aligned with the Keys listed in JWK spec.

## RCA
Turns out that the default Output Serializer on Functions is `NewtonSoft` (https://github.com/Azure/azure-functions-host/blob/v3.x/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs#L75) whereas the default Input Serializer is System.Text.Json.

> Per the Compliance guidelines, we also should not be using `System.Text.Json` due to security reasons.

There are marked differences between how the 2 work and because when using `Serializer` from `System.Text.Json` (Since it was Microsoft's own), it was not honoring the `JsonPropertyName` attribute on the JWK Class.

## Fix
Updated to use `NewtonSoft.Json` when Serializing the JWK.
 