### PR TITLE
Patch CVE-2020-7720: Upgrade selfsigned and node-forge to latest versions 

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10024,9 +10024,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -13259,12 +13259,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {


### PR DESCRIPTION
## Issue
The package `node-forge` before **0.10.0** is vulnerable to **Prototype Pollution** via the `util.setPath` function. 

**Vulnerable versions**: < 0.10.0
**Patched version**: 0.10.0

> Note: Version 0.10.0 is a breaking change removing the vulnerable functions.

## Description
Updates `selfsigned` jslib to latest version which introduces `node-forge` dependency in Learn-LTI. `selfsigned` itself is introduced via `webpack-dev-server`.

> See, https://github.com/webpack/webpack-dev-server/issues/2739 and https://github.com/jfromaniello/selfsigned/pull/39 for details
