### PR TITLE
Fixing broken azuredeploy.json due to license header

### DIFF
--- a/deployment/azuredeploy.json
+++ b/deployment/azuredeploy.json
@@ -1,7 +1,3 @@
-// --------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-// --------------------------------------------------------------------------------------------
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",


### PR DESCRIPTION
## Background
Comments are not allowed in `azuredeploy.json` per this github discussion: https://github.com/Azure/azure-cli/issues/13518.

## Proposed Change
Updated the file to not include any comment,. i.e. the license header in this case.