### PR TITLE
Adding cleanup script to remove deployed Resources via run.bat

### DIFF
--- a/deployment/Cleanup.ps1
+++ b/deployment/Cleanup.ps1
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
 [CmdletBinding()]
 param (
     [string]$ResourceGroupName = "MSLearnLTI",

--- a/deployment/Cleanup.ps1
+++ b/deployment/Cleanup.ps1
@@ -1,0 +1,162 @@
+[CmdletBinding()]
+param (
+    [string]$ResourceGroupName = "MSLearnLTI",
+    [string]$AppName = "MS-Learn-Lti-Tool-App",
+    [string]$IdentityName = "MSLearnLTI-Identity",
+    [switch]$UseActiveAzureAccount,
+    [string]$SubscriptionName = $null
+)
+
+process {
+    function Write-Title([string]$Title) {
+        Write-Host "`n`n============================================================="
+        Write-Host $Title
+        Write-Host "=============================================================`n`n"
+    }
+
+    #region Show Learn LTI Banner
+    Write-Host ''
+    Write-Host ' _      ______          _____  _   _            _   _______ _____ '
+    Write-Host '| |    |  ____|   /\   |  __ \| \ | |          | | |__   __|_   _|'
+    Write-Host '| |    | |__     /  \  | |__) |  \| |  ______  | |    | |    | |  '
+    Write-Host '| |    |  __|   / /\ \ |  _  /| . ` | |______| | |    | |    | |  '
+    Write-Host '| |____| |____ / ____ \| | \ \| |\  |          | |____| |   _| |_ '
+    Write-Host '|______|______/_/    \_\_|  \_\_| \_|          |______|_|  |_____|'
+    Write-Host ''
+    Write-Host ''
+    #endregion
+
+    #region Setup Logging
+    . .\Write-Log.ps1
+    $ScriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+    $ExecutionStartTime = $(get-date -f dd-MM-yyyy-HH-mm-ss)
+    $LogRoot = Join-Path $ScriptPath "Log"
+
+    $LogFile = Join-Path $LogRoot "Log-$ExecutionStartTime.log"
+    Set-LogFile -Path $LogFile
+    
+    $TranscriptFile = Join-Path $LogRoot "Transcript-$ExecutionStartTime.log"
+    Start-Transcript -Path $TranscriptFile;
+    #endregion
+    
+    #region Login to Azure CLI
+    Write-Title 'STEP #1 - Logging into Azure'
+
+    function Test-LtiActiveAzAccount {
+        $account = az account show | ConvertFrom-Json
+        if(!$account) {
+            throw "Error while trying to get Active Account Info."
+        }            
+    }
+
+    function Connect-LtiAzAccount {
+        $loginOp = az login | ConvertFrom-Json
+        if(!$loginOp) {
+            throw "Encountered an Error while trying to Login."
+        }
+    }
+
+    if ($UseActiveAzureAccount) { 
+        Write-Log -Message "Using Active Azure Account"
+        Test-LtiActiveAzAccount
+    }
+    else { 
+        Write-Log -Message "Logging in to Azure"
+        Connect-LtiAzAccount
+    }
+
+    Write-Log -Message "Successfully logged in to Azure."    
+    #endregion
+
+    #region Choose Active Subscription
+    Write-Title 'STEP #2 - Choose Subscription'
+
+    function Get-LtiSubscriptionList {
+        $AzAccountList = ((az account list --all --output json) | ConvertFrom-Json)
+        if(!$AzAccountList) {
+            throw "Encountered an Error while trying to fetch Subscription List."
+        }
+        Write-Output $AzAccountList
+    }
+
+    function Set-LtiActiveSubscription {
+        param (
+            [string]$Name,
+            $List
+        )
+        
+        $subscription = ($List | Where-Object { $_.name -ceq $Name })
+        if(!$subscription) {
+            throw "Invalid Subscription Name Entered."
+        }
+        az account set --subscription $Name
+        #Intentionally not catching an exception here since the set subscription commands behavior (output) is different from others
+        
+        Write-Output $subscription
+    }
+
+    Write-Log -Message "Fetching List of Subscriptions in Users Account"
+    $SubscriptionList = Get-LtiSubscriptionList
+    Write-Log -Message "List of Subscriptions:-`n$($SubscriptionList | ConvertTo-Json -Compress)"    
+
+    $SubscriptionCount = ($SubscriptionList | Measure-Object).Count
+    Write-Log -Message "Count of Subscriptions: $SubscriptionCount"
+    if ($SubscriptionCount -eq 0) {
+        throw "Please create at least ONE Subscription in your Azure Account"
+    }
+    elseif ($SubscriptionName) {
+        Write-Log -Message "Using User provided Subscription Name: $SubscriptionName"            
+    }
+    elseif ($SubscriptionCount -eq 1) {
+        $SubscriptionName = $SubscriptionList[0].name;
+        Write-Log -Message "Defaulting to Subscription Name: $SubscriptionName"
+    }
+    else {
+        $SubscriptionListOutput = $SubscriptionList | Select-Object @{ l="Subscription Name"; e={ $_.name } }, "id", "isDefault"
+        Write-Host ($SubscriptionListOutput | Out-String)
+        $SubscriptionName = Read-Host 'Enter Subscription Name from Above List'
+        Write-Log -Message "User Entered Subscription Name: $SubscriptionName"
+    }
+
+    $ActiveSubscription = Set-LtiActiveSubscription -Name $SubscriptionName -List $SubscriptionList
+    #endregion
+
+    #region Delete Managed Identity, if Exists
+    $Identity = ((az identity list --resource-group $ResourceGroupName) | ConvertFrom-Json) | Where-Object { $_.name -ieq $IdentityName }
+    if (!$Identity) {
+        throw "Unable to find a managed identity with name [ $IdentityName ]"
+    }
+
+    Write-Title 'STEP #3 - Remove Identity as Contributor from Subscription'
+    az role assignment delete --assignee "$($Identity.principalId)" --role 'Contributor'
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to remove Identity [ $IdentityName ] as Contributor"
+    }
+    
+    Write-Title 'STEP #4 - Delete Managed Identity'
+    az identity delete --name $IdentityName --resource-group $ResourceGroupName
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to delete Managed Identity [ $IdentityName ]"
+    }
+    #endregion
+    
+    #region Delete Resource Group, if Exists
+    Write-Title 'STEP #4 - Delete Resource Group'
+    az group delete --name $ResourceGroupName --yes
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to delete Resource Group [ $ResourceGroup ] and its Child Resources"
+    }
+    #endregion
+
+    #region Delete App Registration, if Exists
+    Write-Title 'STEP #5 - Delete App Registration'
+    $AppInfo = (az ad app list --display-name $AppName) | ConvertFrom-Json
+    if (!$AppInfo) {
+        throw "Unable to find App Registration with Name [ $AppName ]"
+    }
+    az ad app delete --id $AppInfo.appId
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to delete AAD App [ $AppName ]"
+    }
+    #endregion
+}

--- a/deployment/Cleanup.ps1
+++ b/deployment/Cleanup.ps1
@@ -137,14 +137,14 @@ process {
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to remove Identity [ $IdentityName ] as Contributor"
     }
-    Write-Host 'Identity as Contributor from Subscription Removed Successfully';
+    Write-Host 'Identity as Contributor from Subscription Removed Successfully'
     
     Write-Title 'STEP #4 - Delete Managed Identity'
     az identity delete --name $IdentityName --resource-group $ResourceGroupName
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to delete Managed Identity [ $IdentityName ]"
     }
-    Write-Host 'Managed Identity Deleted Successfully';
+    Write-Host 'Managed Identity Deleted Successfully'
     #endregion
     
     #region Delete Resource Group, if Exists
@@ -153,7 +153,7 @@ process {
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to delete Resource Group [ $ResourceGroupName ] and its Child Resources"
     }
-    Write-Host 'Resource Group Deleted Successfully';
+    Write-Host 'Resource Group Deleted Successfully'
     #endregion
 
     #region Delete App Registration, if Exists
@@ -166,6 +166,6 @@ process {
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to delete AAD App [ $AppName ]"
     }
-    Write-Host 'App Registration Deleted Successfully';
+    Write-Host 'App Registration Deleted Successfully'
     #endregion
 }

--- a/deployment/Cleanup.ps1
+++ b/deployment/Cleanup.ps1
@@ -85,7 +85,7 @@ process {
             $List
         )
         
-        $subscription = ($List | Where-Object { $_.name -ceq $Name })
+        $subscription = ($List | Where-Object { $_.name -ieq $Name })
         if(!$subscription) {
             throw "Invalid Subscription Name Entered."
         }
@@ -132,24 +132,27 @@ process {
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to remove Identity [ $IdentityName ] as Contributor"
     }
+    Write-Host 'Identity as Contributor from Subscription Removed Successfully';
     
     Write-Title 'STEP #4 - Delete Managed Identity'
     az identity delete --name $IdentityName --resource-group $ResourceGroupName
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to delete Managed Identity [ $IdentityName ]"
     }
+    Write-Host 'Managed Identity Deleted Successfully';
     #endregion
     
     #region Delete Resource Group, if Exists
-    Write-Title 'STEP #4 - Delete Resource Group'
+    Write-Title 'STEP #5 - Delete Resource Group'
     az group delete --name $ResourceGroupName --yes
     if ($LASTEXITCODE -ne 0) {
-        throw "Unable to delete Resource Group [ $ResourceGroup ] and its Child Resources"
+        throw "Unable to delete Resource Group [ $ResourceGroupName ] and its Child Resources"
     }
+    Write-Host 'Resource Group Deleted Successfully';
     #endregion
 
     #region Delete App Registration, if Exists
-    Write-Title 'STEP #5 - Delete App Registration'
+    Write-Title 'STEP #6 - Delete App Registration'
     $AppInfo = (az ad app list --display-name $AppName) | ConvertFrom-Json
     if (!$AppInfo) {
         throw "Unable to find App Registration with Name [ $AppName ]"
@@ -158,5 +161,6 @@ process {
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to delete AAD App [ $AppName ]"
     }
+    Write-Host 'App Registration Deleted Successfully';
     #endregion
 }

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -203,7 +203,7 @@ try {
         throw "Encountered an Error while creating Role Assignment"
     }
 
-    Write-Host 'Role Assignment Created Successfully';
+    Write-Host 'Role Assignment Created Successfully'
 
     Write-Title 'STEP #8 - Creating Resources in Azure'
 

--- a/deployment/Write-Log.ps1
+++ b/deployment/Write-Log.ps1
@@ -1,0 +1,55 @@
+[System.IO.FileInfo]$Script:LTI_LOG_FILE = $null
+
+function Write-LogInternal {
+    param (
+        [Parameter(Mandatory)]
+        [String]$Message
+    )
+    
+    $now = (Get-Date).ToString()
+    $logMsg = "[ $now ] - $Message"
+    
+    if( $Script:LTI_LOG_FILE ) {
+        $logMsg >> $Script:LTI_LOG_FILE
+        # Print the output on the screen, if running verbose
+        Write-Verbose -Message $logMsg
+    }
+    else {
+        # No LogFile set, print output on screen instead
+        Write-Host $logMsg
+    }
+}
+
+function Set-LogFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [System.IO.FileInfo]$Path
+    )
+    
+    process {
+        # We'd append the logs to this File
+        $Script:LTI_LOG_FILE = $Path
+    }
+}
+
+function Write-Log {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Message,
+        $ErrorRecord
+    )
+
+    process {
+        # credits: Tim Curwick for providing this insight
+        if( $ErrorRecord -is [System.Management.Automation.ErrorRecord] ) {
+            Write-LogInternal "[ERROR] - Exception.Message [ $($ErrorRecord.Exception.Message) ]"
+            Write-LogInternal "[ERROR] - Exception.Type    [ $($ErrorRecord.Exception.GetType()) ]"
+            Write-LogInternal "[ERROR] - $Message"
+        }
+        else {
+            Write-LogInternal "[INFO] - $Message"
+        }
+    }
+}

--- a/deployment/Write-Log.ps1
+++ b/deployment/Write-Log.ps1
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
 [System.IO.FileInfo]$Script:LTI_LOG_FILE = $null
 
 function Write-LogInternal {


### PR DESCRIPTION
## Description
Adding a `Cleanup.ps1` script to delete all the resources created via `Deploy.ps1` (which is internally triggered by `run.bat`).

## Execution Instructions
- Launch a powershell and run `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` to ensure the script executes correctly.
- Execute the script by giving it the name of Resource Group, Identity and App Registration used at the time of deployment. By default, these values are set to match `Deploy.ps1`. 

## Usage
- Delete a default deployment: `.\Cleanup.ps1`
- Delete a custom deployment: `.\Cleanup.ps1 -ResourceGroupName RgToRemove -AppName AppToRemove -IdentityName IdToRemove`

> Please use `get-help .\Cleanup.ps1` to get more insights into the available parameters for the script.