### PR TITLE
Refactoring Deploy.ps1 and Publish.ps1 to reuse Write-Log.ps1

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
 [CmdletBinding()]
 param (
     [string]$ResourceGroupName = "MSLearnLTI",

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -1,299 +1,287 @@
-# --------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT license.
-# --------------------------------------------------------------------------------------------
+[CmdletBinding()]
+param (
+    [string]$ResourceGroupName = "MSLearnLTI",
+    [string]$AppName = "MS-Learn-Lti-Tool-App",
+    [string]$IdentityName = "MSLearnLTI-Identity"
+)
 
-$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
-$ExecutionStartTime = $(get-date -f dd-MM-yyyy-HH-mm-ss)
-$LogRoot = Join-Path $scriptPath "Log"
-$LogFile = Join-Path $LogRoot "Log-$ExecutionStartTime.log"
-$resourceGroupName = "MSLearnLTI"
-$identityName = "MSLearnLTI-Identity"
-$appName = "MS-Learn-Lti-Tool-App"
-
-function Write-LogInternal {
-    param (
-        [Parameter(Mandatory)]
-        [String]$Message
-    )
+process {
+    function Write-Title([string]$Title) {
+        Write-Host "`n`n============================================================="
+        Write-Host $Title
+        Write-Host "=============================================================`n`n"
+    }
     
-    $now = (Get-Date).ToString()
-    $logMsg = "[ $now ] - $Message"
-    $logMsg >> $LogFile
+    try {
 
-    # Print the output on the screen, if running verbose
-    Write-Verbose -Message $logMsg
-}
-
-function Write-Log {
-    param (
-        [Parameter(Mandatory)]
-        [string]$Message,
-        $ErrorRecord
-    )
-
-    # credits: Tim Curwick for providing this insight
-    if( $ErrorRecord -is [System.Management.Automation.ErrorRecord] ) {
-        Write-LogInternal "[ERROR] - Exception.Message [ $($ErrorRecord.Exception.Message) ]"
-        Write-LogInternal "[ERROR] - Exception.Type    [ $($ErrorRecord.Exception.GetType()) ]"
-        Write-LogInternal "[ERROR] - $Message"
-    }
-    else {
-        Write-LogInternal "[INFO] - $Message"
-    }
-}
-
-function Write-Banner {
-    Write-Host ''
-    Write-Host ' _      ______          _____  _   _            _   _______ _____ '
-    Write-Host '| |    |  ____|   /\   |  __ \| \ | |          | | |__   __|_   _|'
-    Write-Host '| |    | |__     /  \  | |__) |  \| |  ______  | |    | |    | |  '
-    Write-Host '| |    |  __|   / /\ \ |  _  /| . ` | |______| | |    | |    | |  '
-    Write-Host '| |____| |____ / ____ \| | \ \| |\  |          | |____| |   _| |_ '
-    Write-Host '|______|______/_/    \_\_|  \_\_| \_|          |______|_|  |_____|'
-    Write-Host ''    
-    Write-Host ''    
-}
-
-function Write-Title([string]$Title) {
-    Write-Host "`n`n============================================================="
-    Write-Host $Title
-    Write-Host "=============================================================`n`n"
-}
-
-try {
-    Write-Banner
-    
-    $TranscriptFile = Join-Path $LogRoot "Transcript-$ExecutionStartTime.log"
-    Start-Transcript -Path $TranscriptFile;
-
-    Write-Title 'STEP #1 - Logging into Azure'
-
-    Write-Log -Message "Logging in to Azure"
-    $loginOp = az login | ConvertFrom-Json
-    if(!$loginOp) {
-        throw "Encountered an Error while trying to Login."
-    }
-    Write-Log -Message "Successfully logged in to Azure."
-
-    Write-Title 'STEP #2 - Choose Subscription'
-
-    Write-Log -Message "Fetching List of Subscriptions in Users Account"
-
-    $subscriptionList = ((az account list --all --output json) | ConvertFrom-Json);
-    if(!$subscriptionList) {
-        throw "Encountered an Error while trying to fetch Subscription List."
-    }
-
-    Write-Log -Message "List of Subscriptions:-`n$($subscriptionList | ConvertTo-Json -Compress)"
-
-    $subscriptionCount = 0;
-    foreach ($subscription in $subscriptionList) {
-        $subscriptionCount += 1;
-    }
-
-    Write-Log -Message "Count of Subscriptions: $subscriptionCount"
-
-    if ($subscriptionCount -eq 0) {
-        throw "Please create atlease ONE Subscription in your Azure Account"
-    }
-    if ($subscriptionCount -eq 1) {
-        $subscriptionName = $subscriptionList[0].name;
-        Write-Log -Message "Defaulting to Subscription with Name: $subscriptionName"
-    }
-    else {
-        $subscriptionListOutput = az account list --output table --all --query "[].{Name:name, Id:id IsDefault:isDefault}"
-        $subscriptionListOutput;
+        #region Show Learn LTI Banner
+        Write-Host ''
+        Write-Host ' _      ______          _____  _   _            _   _______ _____ '
+        Write-Host '| |    |  ____|   /\   |  __ \| \ | |          | | |__   __|_   _|'
+        Write-Host '| |    | |__     /  \  | |__) |  \| |  ______  | |    | |    | |  '
+        Write-Host '| |    |  __|   / /\ \ |  _  /| . ` | |______| | |    | |    | |  '
+        Write-Host '| |____| |____ / ____ \| | \ \| |\  |          | |____| |   _| |_ '
+        Write-Host '|______|______/_/    \_\_|  \_\_| \_|          |______|_|  |_____|'
         Write-Host ''
         Write-Host ''
-        $subscriptionName = Read-Host 'Enter Subscription Name from Above List'
-        Write-Log -Message "User Entered Subscription Name: $subscriptionName"
+        #endregion
 
-    }
+        #region Setup Logging
+        . .\Write-Log.ps1
+        $ScriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+        $ExecutionStartTime = $(get-date -f dd-MM-yyyy-HH-mm-ss)
+        $LogRoot = Join-Path $ScriptPath "Log"
 
-    $isValidSubscriptionName = $false;
-    foreach ($subscription in $subscriptionList) {
-        if($subscription.name -ieq $subscriptionName) {
-            $isValidSubscriptionName = $true;
-            $userEmailAddress = $subscription.user.name;
-        }
-    }
+        $LogFile = Join-Path $LogRoot "Log-$ExecutionStartTime.log"
+        Set-LogFile -Path $LogFile
+        
+        $TranscriptFile = Join-Path $LogRoot "Transcript-$ExecutionStartTime.log"
+        Start-Transcript -Path $TranscriptFile;
+        #endregion
 
-    if(!$isValidSubscriptionName) {
-        throw "Invalid Subscription Name Entered."
-    }
-
-    $setSubscriptionNameOp = (az account set --subscription $subscriptionName)
-    #Intentionally not catching an exception here since the set subscription commands behavior (output) is different from others
-
-
-    Write-Title("STEP #3 - Choose Location `n(Please refer to the Documentation / ReadMe on Github for the List of Supported Locations)");
-
-    Write-Log -Message "Fetching List of Locations"
-    $locationList = (az account list-locations) | ConvertFrom-Json;
-
-    Write-Log -Message "List of Locations:-`n$($locationList | ConvertTo-Json -Compress)"
-    az account list-locations --output table --query "[].{Name:name}"
-
-    Write-Host ''
-    Write-Host ''
-    $locationName = Read-Host 'Enter Location From Above List for Resource Provisioning'
-    Write-Log -Message "User Entered Location Name: $locationName"
-    $isValidLocationName = $false;
-    foreach ($location in $locationList) {
-        if($location.name -ieq $locationName) {
-            $isValidLocationName = $true;
-        }
-    }
-
-    if(!$isValidLocationName) {
-        throw "Invalid Location Name Entered."
-    }
-
-
-    Write-Title 'STEP #4 - Registering Azure Active Directory App'
-
-    Write-Log -Message "Creating AAD App with Name: $appName"
-    $appinfo=$(az ad app create --display-name $appName) | ConvertFrom-Json;
-    if(!$appinfo) {
-        throw "Encountered an Error while creating AAD App"
-    }
-    $identifierURI = "api://$($appinfo.appId)";
-    Write-Log -Message "Updating Identifier URI's in AAD App to: [ api://$($appinfo.appId) ]"
-    $appUpdateOp = az ad app update --id $appinfo.appId --identifier-uris $identifierURI;
-    #Intentionally not catching an exception here since the app update commands behavior (output) is different from others
-
-    Write-Log -Message "Updating App so as to add MS Graph -> User Profile -> Read Permissions to the AAD App"
-    $GraphAPIId = '00000003-0000-0000-c000-000000000000'
-    $GraphAPIPermissionId = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope'
-    $appPermissionAddOp = az ad app permission add --id $appinfo.appId --api $GraphAPIId --api-permissions $GraphAPIPermissionId
-    #Intentionally not catching an exception here
-
-    Write-Host 'App Created Successfully'
-
-    Write-Title 'STEP #5 - Creating Resource Group'
-
-    Write-Log -Message "Creating Resource Group with Name: $resourceGroupName at Location: $locationName"
-    $resourceGroupCreationOp = az group create -l $locationName -n $resourceGroupName
-    if(!$resourceGroupCreationOp) {
-        throw "Encountered an Error while creating Resource Group with Name : " + $resourceGroupName + " at Location: " + $locationName + ". One Reason could be that the Resource Group with the same name but different location already exists in your Subscription. Delete the other Resource Group and run this script again."
-    }
-
-    Write-Host 'Resource Group Created Successfully'
-
-    Write-Title 'STEP #6 - Creating Managed Identity'
-
-    Write-Log -Message "Creating Managed identity inside ResourceGroup: $resourceGroupName and Identity Name: $identityName"
-    $identityObj = (az identity create -g $resourceGroupName -n $identityName) | ConvertFrom-Json
-    if(!$identityObj) {
-        throw "Encountered an Error while creating managed identity inside ResourceGroup: " + $resourceGroupName + " and Identity Name: " + $identityName
-    }
-
-    #It takes a few seconds for the Managed Identity to spin up and be available for further processing
-    Write-Log -Message "Sleeping for 30 seconds"
-    Start-Sleep -s 30
-    Write-Host 'Managed Identity Created Successfully'
-
-    Write-Title 'STEP #7 - Creating Role Assignment'
-
-    $roleName = "Contributor"
-    Write-Log -Message "Assigning Role: $roleName to PrincipalID: $($identityObj.principalId)"
-    $roleAssignmentOp = az role assignment create --assignee-object-id $identityObj.principalId --assignee-principal-type ServicePrincipal --role $roleName
-    if(!$roleAssignmentOp) {
-        throw "Encountered an Error while creating Role Assignment"
-    }
-
-    Write-Host 'Role Assignment Created Successfully'
-
-    Write-Title 'STEP #8 - Creating Resources in Azure'
-
-    $userObjectId = az ad signed-in-user show --query objectId
-    #$userObjectId
-
-    $templateFileName = "azuredeploy.json"
-    $deploymentName = "Deployment-$ExecutionStartTime"
-    Write-Log -Message "Deploying ARM Template to Azure inside ResourceGroup: $resourceGroupName with DeploymentName: $deploymentName, TemplateFile: $templateFileName, AppClientId: $($appinfo.appId), IdentifiedURI: $($appinfo.identifierUris)"
-    $deploymentOutput = (az deployment group create --resource-group $resourceGroupName --name $deploymentName --template-file $templateFileName --parameters appRegistrationClientId=$($appinfo.appId) appRegistrationApiURI=$($identifierURI) identityName=$($identityName) userEmailAddress=$($userEmailAddress) userObjectId=$($userObjectId)) | ConvertFrom-Json;
-    if(!$deploymentOutput) {
-        throw "Encountered an Error while deploying to Azure"
-    }
-
-    #Updating the Config Entry EdnaLiteDevKey in the Function Config
-    function Update-LtiFunctionAppSettings([string]$ResourceGroupName, [string]$FunctionAppName, [hashtable]$AppSettings) {
-        Write-Log -Message "Updating App Settings for Function App [ $FunctionAppName ]: -"
-        foreach ($it in $AppSettings.GetEnumerator()) {
-            Write-Log -Message "`t[ $($it.Name) ] = [ $($it.Value) ]"
-            az functionapp config appsettings set --resource-group $ResourceGroupName --name $FunctionAppName --settings "$($it.Name)=$($it.Value)"
-        }
-    }
-
-    $KeyVaultLink=$(az keyvault key show --vault-name $deploymentOutput.properties.outputs.KeyVaultName.value --name EdnaLiteDevKey --query 'key.kid' -o json);
-    $EdnaKeyString = @{ "EdnaKeyString"="$KeyVaultLink" }
-    $ConnectUpdateOp = Update-LtiFunctionAppSettings $resourceGroupName $deploymentOutput.properties.outputs.ConnectFunctionName.value $EdnaKeyString
-    $PlatformsUpdateOp = Update-LtiFunctionAppSettings $resourceGroupName $deploymentOutput.properties.outputs.PlatformsFunctionName.value $EdnaKeyString
-    $UsersUpdateOp = Update-LtiFunctionAppSettings $resourceGroupName $deploymentOutput.properties.outputs.UsersFunctionName.value $EdnaKeyString
-
-    Write-Host 'Resource Creation in Azure Completed Successfully'
-
-    Write-Title 'STEP #9 - Updating AAD App'
-
-    $AppRedirectUrl = $deploymentOutput.properties.outputs.webClientURL.value
-    Write-Log -Message "Updating App with ID: $($appinfo.appId) to Redirect URL: $AppRedirectUrl and also enabling Implicit Flow"
-    $appUpdateRedirectUrlOp = az ad app update --id $appinfo.appId --reply-urls $AppRedirectUrl --oauth2-allow-implicit-flow true
-    #Intentionally not catching an exception here since the app update commands behavior (output) is different from others
-
-    Write-Host 'App Update Completed Successfully'
-
-    . .\Install-Backend.ps1
-    Write-Title "STEP #10 - Installing the backend"
-
-    $BackendParams = @{
-        SourceRoot="../backend";
-        ResourceGroupName=$resourceGroupName;
-        LearnContentFunctionAppName=$deploymentOutput.properties.outputs.LearnContentFunctionName.value;
-        LinksFunctionAppName=$deploymentOutput.properties.outputs.LinksFunctionName.value;
-        AssignmentsFunctionAppName=$deploymentOutput.properties.outputs.AssignmentsFunctionName.value;
-        ConnectFunctionAppName=$deploymentOutput.properties.outputs.ConnectFunctionName.value;
-        PlatformsFunctionAppName=$deploymentOutput.properties.outputs.PlatformsFunctionName.value;
-        UsersFunctionAppName=$deploymentOutput.properties.outputs.UsersFunctionName.value;
-    }
-    Install-Backend @BackendParams
-
-    . .\Install-Client.ps1
-    Write-Title "STEP #11 - Updating client's .env.production file"
-
-    $ClientUpdateConfigParams = @{
-        ConfigPath="../client/.env.production";
-        AppId=$appinfo.appId;
-        LearnContentFunctionAppName=$deploymentOutput.properties.outputs.LearnContentFunctionName.value;
-        LinksFunctionAppName=$deploymentOutput.properties.outputs.LinksFunctionName.value;
-        AssignmentsFunctionAppName=$deploymentOutput.properties.outputs.AssignmentsFunctionName.value;
-        PlatformsFunctionAppName=$deploymentOutput.properties.outputs.PlatformsFunctionName.value;
-        UsersFunctionAppName=$deploymentOutput.properties.outputs.UsersFunctionName.value;
-        StaticWebsiteUrl=$deploymentOutput.properties.outputs.webClientURL.value;
-    }
-    Update-ClientConfig @ClientUpdateConfigParams
-
-    Write-Title 'STEP #12 - Installing the client'
-    $ClientInstallParams = @{
-        SourceRoot="../client";
-        StaticWebsiteStorageAccount=$deploymentOutput.properties.outputs.StaticWebSiteName.value
-    }
-    Install-Client @ClientInstallParams
-
+        #region Login to Azure CLI        
+        Write-Title 'STEP #1 - Logging into Azure'
     
-    Write-Title "TOOL REGISTRATION URL (Please Copy, Required for Next Steps) -> $($deploymentOutput.properties.outputs.webClientURL.value)platform"
+        Write-Log -Message "Logging in to Azure"
+        $loginOp = az login | ConvertFrom-Json
+        if(!$loginOp) {
+            throw "Encountered an Error while trying to Login."
+        }
+        Write-Log -Message "Successfully logged in to Azure."
+        #endregion
 
-    Write-Title '======== Successfully Deployed Resources to Azure ==========='    
+        #region Choose Active Subcription 
+        Write-Title 'STEP #2 - Choose Subscription'
+    
+        Write-Log -Message "Fetching List of Subscriptions in Users Account"
+    
+        $subscriptionList = ((az account list --all --output json) | ConvertFrom-Json);
+        if(!$subscriptionList) {
+            throw "Encountered an Error while trying to fetch Subscription List."
+        }
+    
+        Write-Log -Message "List of Subscriptions:-`n$($subscriptionList | ConvertTo-Json -Compress)"
+    
+        $subscriptionCount = 0;
+        foreach ($subscription in $subscriptionList) {
+            $subscriptionCount += 1;
+        }
+    
+        Write-Log -Message "Count of Subscriptions: $subscriptionCount"
+    
+        if ($subscriptionCount -eq 0) {
+            throw "Please create atlease ONE Subscription in your Azure Account"
+        }
+        if ($subscriptionCount -eq 1) {
+            $subscriptionName = $subscriptionList[0].name;
+            Write-Log -Message "Defaulting to Subscription with Name: $subscriptionName"
+        }
+        else {
+            $subscriptionListOutput = az account list --output table --all --query "[].{Name:name, Id:id IsDefault:isDefault}"
+            $subscriptionListOutput;
+            Write-Host ''
+            Write-Host ''
+            $subscriptionName = Read-Host 'Enter Subscription Name from Above List'
+            Write-Log -Message "User Entered Subscription Name: $subscriptionName"
+    
+        }
 
-    Write-Log -Message "Deployment Complete"
-}
-catch {
-    $Message = 'Error occurred while executing the Script. Please report the bug on Github (along with Error Message & Logs)'
-    Write-Log -Message $Message -ErrorRecord $_
-    throw $_
-}
-finally {
-    Stop-Transcript
-    $exit = Read-Host 'Press any Key to Exit'
+        $isValidSubscriptionName = $false;
+        foreach ($subscription in $subscriptionList) {
+            if($subscription.name -ceq $subscriptionName) {
+                $isValidSubscriptionName = $true;
+                $userEmailAddress = $subscription.user.name;
+            }
+        }
+    
+        if(!$isValidSubscriptionName) {
+            throw "Invalid Subscription Name Entered."
+        }
+    
+        $setSubscriptionNameOp = (az account set --subscription $subscriptionName)
+        #Intentionally not catching an exception here since the set subscription commands behavior (output) is different from others
+        #endregion
+
+        #region Choose Region for Deployment
+        Write-Title "STEP #3 - Choose Location`n(Please refer to the Documentation / ReadMe on Github for the List of Supported Locations)"
+
+        Write-Log -Message "Fetching List of Locations"
+        $locationList = (az account list-locations) | ConvertFrom-Json;
+
+        Write-Log -Message "List of Locations:-`n$($locationList | ConvertTo-Json -Compress)"
+        az account list-locations --output table --query "[].{Name:name}"
+    
+        Write-Host ''
+        Write-Host ''
+        $locationName = Read-Host 'Enter Location From Above List for Resource Provisioning'
+        Write-Log -Message "User Entered Location Name: $locationName"
+        $isValidLocationName = $false;
+        foreach ($location in $locationList) {
+            if($location.name -ceq $locationName) {
+                $isValidLocationName = $true;
+            }
+        }
+    
+        if(!$isValidLocationName) {
+            throw "Invalid Location Name Entered."
+        }
+        #endregion
+    
+        #region Create New App Registration in AzureAD
+        Write-Title 'STEP #4 - Registering Azure Active Directory App'
+    
+        Write-Log -Message "Creating AAD App with Name: $AppName"
+        $appinfo=$(az ad app create --display-name $AppName) | ConvertFrom-Json;
+        if(!$appinfo) {
+            throw "Encountered an Error while creating AAD App"
+        }
+        $identifierURI = "api://$($appinfo.appId)";
+        Write-Log -Message "Updating Identifier URI's in AAD App to: [ api://$($appinfo.appId) ]"
+        $appUpdateOp = az ad app update --id $appinfo.appId --identifier-uris $identifierURI;
+        #Intentionally not catching an exception here since the app update commands behavior (output) is different from others
+    
+        Write-Log -Message "Updating App so as to add MS Graph -> User Profile -> Read Permissions to the AAD App"
+        $GraphAPIId = '00000003-0000-0000-c000-000000000000'
+        $GraphAPIPermissionId = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope'
+        $appPermissionAddOp = az ad app permission add --id $appinfo.appId --api $GraphAPIId --api-permissions $GraphAPIPermissionId
+        #Intentionally not catching an exception here
+    
+        Write-Host 'App Created Successfully'
+        #endregion
+    
+        #region Create New Resource Group in above Region
+        Write-Title 'STEP #5 - Creating Resource Group'
+    
+        Write-Log -Message "Creating Resource Group with Name: $ResourceGroupName at Location: $locationName"
+        $resourceGroupCreationOp = az group create -l $locationName -n $ResourceGroupName
+        if(!$resourceGroupCreationOp) {
+            throw "Encountered an Error while creating Resource Group with Name : " + $ResourceGroupName + " at Location: " + $locationName + ". One Reason could be that the Resource Group with the same name but different location already exists in your Subscription. Delete the other Resource Group and run this script again."
+        }
+    
+        Write-Host 'Resource Group Created Successfully'
+        #endregion
+
+        #region Create new Managed Contrbuter for deploying resources via ARM template
+        Write-Title 'STEP #6 - Creating Managed Identity'
+
+        Write-Log -Message "Creating Managed Identity inside ResourceGroup [ $ResourceGroupName ] with Name [ $IdentityName ]"
+        $identityObj = (az identity create -g $ResourceGroupName -n $IdentityName) | ConvertFrom-Json
+        if(!$identityObj) {
+            throw "Error while creating Managed Identity inside ResourceGroup [ $ResourceGroupName ] with Name [ $IdentityName ]" 
+        }
+    
+        #It takes a few seconds for the Managed Identity to spin up and be available for further processing
+        Write-Log -Message "Sleeping for 30 seconds"
+        Start-Sleep -s 30
+        Write-Host 'Managed Identity Created Successfully'
+
+        Write-Title 'STEP #7 - Creating Role Assignment'
+    
+        $roleName = "Contributor"
+        Write-Log -Message "Assigning Role: $roleName to PrincipalID: $($identityObj.principalId)"
+        $roleAssignmentOp = az role assignment create --assignee-object-id $identityObj.principalId --assignee-principal-type ServicePrincipal --role $roleName
+        if(!$roleAssignmentOp) {
+            throw "Encountered an Error while creating Role Assignment"
+        }
+    
+        Write-Host 'Role Assignment Created Successfully';
+        #endregion
+
+        #region Provision Resources inside Resource Group on Azure using ARM template
+        Write-Title 'STEP #8 - Creating Resources in Azure'
+    
+        $userObjectId = az ad signed-in-user show --query objectId
+        #$userObjectId
+    
+        $templateFileName = "azuredeploy.json"
+        $deploymentName = "Deployment-$ExecutionStartTime"
+        Write-Log -Message "Deploying ARM Template to Azure inside ResourceGroup: $ResourceGroupName with DeploymentName: $deploymentName, TemplateFile: $templateFileName, AppClientId: $($appinfo.appId), IdentifiedURI: $($appinfo.identifierUris)"
+        $deploymentOutput = (az deployment group create --resource-group $ResourceGroupName --name $deploymentName --template-file $templateFileName --parameters appRegistrationClientId=$($appinfo.appId) appRegistrationApiURI=$($identifierURI) identityName=$($IdentityName) userEmailAddress=$($userEmailAddress) userObjectId=$($userObjectId)) | ConvertFrom-Json;
+        if(!$deploymentOutput) {
+            throw "Encountered an Error while deploying to Azure"
+        }
+    
+        function Update-LtiFunctionAppSettings([string]$ResourceGroupName, [string]$FunctionAppName, [hashtable]$AppSettings) {
+            Write-Log -Message "Updating App Settings for Function App [ $FunctionAppName ]: -"
+            foreach ($it in $AppSettings.GetEnumerator()) {
+                Write-Log -Message "`t[ $($it.Name) ] = [ $($it.Value) ]"
+                az functionapp config appsettings set --resource-group $ResourceGroupName --name $FunctionAppName --settings "$($it.Name)=$($it.Value)"
+            }
+        }
+    
+        #Updating the Config Entry EdnaLiteDevKey in the Function Config
+        $KeyVaultLink=$(az keyvault key show --vault-name $deploymentOutput.properties.outputs.KeyVaultName.value --name EdnaLiteDevKey --query 'key.kid' -o json);
+        $EdnaKeyString = @{ "EdnaKeyString"="$KeyVaultLink" }
+        $ConnectUpdateOp = Update-LtiFunctionAppSettings $ResourceGroupName $deploymentOutput.properties.outputs.ConnectFunctionName.value $EdnaKeyString
+        $PlatformsUpdateOp = Update-LtiFunctionAppSettings $ResourceGroupName $deploymentOutput.properties.outputs.PlatformsFunctionName.value $EdnaKeyString
+        $UsersUpdateOp = Update-LtiFunctionAppSettings $ResourceGroupName $deploymentOutput.properties.outputs.UsersFunctionName.value $EdnaKeyString
+    
+        Write-Host 'Resource Creation in Azure Completed Successfully'
+
+        Write-Title 'STEP #9 - Updating AAD App'
+    
+        $AppRedirectUrl = $deploymentOutput.properties.outputs.webClientURL.value
+        Write-Log -Message "Updating App with ID: $($appinfo.appId) to Redirect URL: $AppRedirectUrl and also enabling Implicit Flow"
+        $appUpdateRedirectUrlOp = az ad app update --id $appinfo.appId --reply-urls $AppRedirectUrl --oauth2-allow-implicit-flow true
+        #Intentionally not catching an exception here since the app update commands behavior (output) is different from others
+    
+        Write-Host 'App Update Completed Successfully'
+        #endregion
+
+        #region Build and Publish Function Apps
+        . .\Install-Backend.ps1
+        Write-Title "STEP #10 - Installing the backend"
+    
+        $BackendParams = @{
+            SourceRoot="../backend";
+            ResourceGroupName=$ResourceGroupName;
+            LearnContentFunctionAppName=$deploymentOutput.properties.outputs.LearnContentFunctionName.value;
+            LinksFunctionAppName=$deploymentOutput.properties.outputs.LinksFunctionName.value;
+            AssignmentsFunctionAppName=$deploymentOutput.properties.outputs.AssignmentsFunctionName.value;
+            ConnectFunctionAppName=$deploymentOutput.properties.outputs.ConnectFunctionName.value;
+            PlatformsFunctionAppName=$deploymentOutput.properties.outputs.PlatformsFunctionName.value;
+            UsersFunctionAppName=$deploymentOutput.properties.outputs.UsersFunctionName.value;
+        }
+        Install-Backend @BackendParams
+        #endregion
+
+        #region Build and Publish Client Artifacts
+        . .\Install-Client.ps1
+        Write-Title "STEP #11 - Updating client's .env.production file"
+    
+        $ClientUpdateConfigParams = @{
+            ConfigPath="../client/.env.production";
+            AppId=$appinfo.appId;
+            LearnContentFunctionAppName=$deploymentOutput.properties.outputs.LearnContentFunctionName.value;
+            LinksFunctionAppName=$deploymentOutput.properties.outputs.LinksFunctionName.value;
+            AssignmentsFunctionAppName=$deploymentOutput.properties.outputs.AssignmentsFunctionName.value;
+            PlatformsFunctionAppName=$deploymentOutput.properties.outputs.PlatformsFunctionName.value;
+            UsersFunctionAppName=$deploymentOutput.properties.outputs.UsersFunctionName.value;
+            StaticWebsiteUrl=$deploymentOutput.properties.outputs.webClientURL.value;
+        }
+        Update-ClientConfig @ClientUpdateConfigParams
+    
+        Write-Title 'STEP #12 - Installing the client'
+        $ClientInstallParams = @{
+            SourceRoot="../client";
+            StaticWebsiteStorageAccount=$deploymentOutput.properties.outputs.StaticWebSiteName.value
+        }
+        Install-Client @ClientInstallParams
+        #endregion
+
+        Write-Title "TOOL REGISTRATION URL (Please Copy, Required for Next Steps) -> $($deploymentOutput.properties.outputs.webClientURL.value)platform"
+
+        Write-Title '======== Successfully Deployed Resources to Azure ==========='
+
+        Write-Log -Message "Deployment Complete"
+    }
+    catch {
+        $Message = 'Error occurred while executing the Script. Please report the bug on Github (along with Error Message & Logs)'
+        Write-Log -Message $Message -ErrorRecord $_
+        throw $_
+    }
+    finally {
+        Stop-Transcript
+        $exit = Read-Host 'Press any Key to Exit'
+    }
 }

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -2,7 +2,8 @@
 param (
     [string]$ResourceGroupName = "MSLearnLTI",
     [string]$AppName = "MS-Learn-Lti-Tool-App",
-    [string]$IdentityName = "MSLearnLTI-Identity"
+    [string]$IdentityName = "MSLearnLTI-Identity",
+    [switch]$UseActiveAzureAccount
 )
 
 process {
@@ -41,12 +42,30 @@ process {
 
         #region Login to Azure CLI        
         Write-Title 'STEP #1 - Logging into Azure'
-    
-        Write-Log -Message "Logging in to Azure"
-        $loginOp = az login | ConvertFrom-Json
-        if(!$loginOp) {
-            throw "Encountered an Error while trying to Login."
+
+        function Test-LtiActiveAzAccount {
+            $account = az account show | ConvertFrom-Json
+            if(!$account) {
+                throw "Error while trying to get Active Account Info."
+            }            
         }
+
+        function Connect-LtiAzAccount {
+            $loginOp = az login | ConvertFrom-Json
+            if(!$loginOp) {
+                throw "Encountered an Error while trying to Login."
+            }
+        }
+
+        if ($UseActiveAzureAccount) { 
+            Write-Log -Message "Using Active Azure Account"
+            Test-LtiActiveAzAccount
+        }
+        else { 
+            Write-Log -Message "Logging in to Azure"
+            Connect-LtiAzAccount
+        }
+
         Write-Log -Message "Successfully logged in to Azure."
         #endregion
 

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -140,8 +140,8 @@ process {
         if(!$LocationName) {
             Write-Host "$(az account list-locations --output table --query "[].{Name:name}" | Out-String)`n"
             $LocationName = Read-Host 'Enter Location From Above List for Resource Provisioning'
-            Write-Log -Message "User Entered Location Name: $LocationName"
         }
+        Write-Log -Message "User Provided Location Name: $LocationName"
 
         $ValidLocation = $LocationList | Where-Object { $_.name -ieq $LocationName }
         if(!$ValidLocation) {

--- a/deployment/Publish.ps1
+++ b/deployment/Publish.ps1
@@ -21,17 +21,6 @@ process {
     # GLOBALS
     $VALID_FUNCTIONS =  @("LearnContent", "Links", "Assignments", "Connect", "Platforms", "Users")
     $VALID_CLIENT = "learnclient"
-
-    # TODO: Move helpers to common file
-    function Write-Log {
-        param(
-            [Parameter(Mandatory)]
-            [string]$Message
-        ) 
-        $now = (Get-Date).ToString();
-        Write-Host "[$now] - $Message";
-    }
-
     function Write-Title {
         param(
             [Parameter(Mandatory)]
@@ -116,6 +105,8 @@ process {
         }
     }
     
+    . .\Write-Log.ps1   # Resolves Write-Log function
+
     Write-Title 'Gathering Deployment Info'
     $resources = Get-DeployedResourceInfo -ResourceGroupName $ResourceGroupName -AppName $AppName
     Write-Title 'Deployment Info Gathered'


### PR DESCRIPTION
## Description
- As a part of creating `Cleanup.ps1`, we refactored logging into a separate utility script of its own. This PR starts re-using that inside `Deploy.ps1` (used via run.bat) and `Publish.ps1` (can be used for only publishing assets to an existing deployment).
- Also, refactored the code inside `Deploy.ps1` to take parameters via command-line as well and moved out exception handling to be more explicit.

## Example with all parameters
``` powershell
Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
.\Deploy.ps1 -ResourceGroupName {rg-name} -AppName {app-name} -IdentityName {id-name} -UseActiveAzureAccount -SubscriptionName {subscription} -LocationName {region}
```

## Testing
- [x] Ensure deployment succeeds with no arguments -- no regression
- [x] Ensure deployment succeeds for custom Resource Group, Identity Name and App Name
- [x] Ensure deployment succeeds when reusing the existing Azure Account (no explicit sign-in)
- [x] Ensure deployment succeeds by passing subscription via command-line (no input other than region)
- [x] Ensure deployment succeeds by passing region via command-line (no input)