### PR TITLE
Update CONFIGURATION_GUIDE.md

### DIFF
--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -40,6 +40,7 @@ The following steps show how to configure an LTI tool on a Moodle LMS.
  * **LTI version**: LTI 1.0/1.1
  * **Consumer key**: key
  * **Shared secret**: secret
+ * For LTI1.1, the current values for Consumer Key and Shared Secret are literal values key and secret. 
  * **Default launch container**: New window
 7. Under **Services**, **IMS LTI Names and Role Provisioning**: select **Use this service to retrieve members’ information as per privacy settings**.
 8. Under **Privacy**, select the following options:


### PR DESCRIPTION
Update doc re For LTI1.1, the current values for Consumer Key and Shared Secret are literal values key and secret. This is also present in the Configuration Guide (see below)