### PR TITLE
Update LTI1.1 Consumer Key/Shared Secret values to LearnLTI/LearnLTI

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+#ide
+.idea
+.vscode

--- a/deployment/azuredeploy.json
+++ b/deployment/azuredeploy.json
@@ -168,7 +168,7 @@
             "properties": {
                 "AuthUrl": "[parameters('appRegistrationApiURI')]",
                 "AssignmentsServiceUrl": "[concat('https://', 'assignments' , variables('ProjectNameSuffix'), '.azurewebsites.net/api/')]",
-                "Lti1Secret": "secret",
+                "Lti1Secret": "LearnLTI",
                 "PlatformsServiceUrl": "[concat('https://', 'platforms', variables('ProjectNameSuffix'), '.azurewebsites.net/api/')]",
                 "RedirectUrl": "[reference(resourceId('Microsoft.Storage/storageAccounts/', variables('staticWebsite'))).primaryEndpoints.web]",
                 "FUNCTIONS_WORKER_RUNTIME": "[variables('runtimeStack')]",
@@ -194,7 +194,7 @@
             "properties": {
                 "AuthUrl": "[parameters('appRegistrationApiURI')]",
                 "AssignmentsServiceUrl": "[concat('https://', 'assignments', variables('ProjectNameSuffix'), '.azurewebsites.net/api/')]",
-                "Lti1Secret": "secret",
+                "Lti1Secret": "LearnLTI",
                 "PlatformsServiceUrl": "[concat('https://', 'platforms', variables('ProjectNameSuffix'), '.azurewebsites.net/api/')]",
                 "RedirectUrl": "[reference(resourceId('Microsoft.Storage/storageAccounts/', variables('staticWebsite'))).primaryEndpoints.web]",
                 "FUNCTIONS_WORKER_RUNTIME": "[variables('runtimeStack')]",

--- a/deployment/run.bat
+++ b/deployment/run.bat
@@ -1,8 +1,8 @@
+@echo off
 REM --------------------------------------------------------------------------------------------
 REM Copyright (c) Microsoft Corporation. All rights reserved.
 REM Licensed under the MIT license.
 REM --------------------------------------------------------------------------------------------
 
-@echo off
 REM Triggers Learn-LTI Deployment and Publishing Script bypassing the Signing requirements
 PowerShell.exe -ExecutionPolicy Bypass -File .\Deploy.ps1

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -38,9 +38,8 @@ The following steps show how to configure an LTI tool on a Moodle LMS.
  * **Tool name**: give the tool a name of your choice. For example: "Microsoft Learn".
  * **Tool URL**: https://[lti-domain-url]/api/launch-lti1 where [lti-domain-url] is the Domain URL field from Microsoft Learn LTI application’s registration page. 
  * **LTI version**: LTI 1.0/1.1
- * **Consumer key**: key
- * **Shared secret**: secret
- * For LTI1.1, the current values for Consumer Key and Shared Secret are literal values key and secret. 
+ * **Consumer key**: LearnLTI
+ * **Shared secret**: LearnLTI
  * **Default launch container**: New window
 7. Under **Services**, **IMS LTI Names and Role Provisioning**: select **Use this service to retrieve members’ information as per privacy settings**.
 8. Under **Privacy**, select the following options:


### PR DESCRIPTION
## Description
- Per LSE and github issue #67, it seems like Consumer Key and Shared Secret values of key and secret and not explicit enough in the documentation for onboarding our tool via LTI1.1.
- Hence, making the changes to make these values a bit more explicit, i.e. using **LearnLTI** for both Consumer Key and Shared Secret.

## Testing
- [x] Ensure that we are able to create a new assignment using LTI1.1 Tool and publish it for students.
- [x] Ensure that `GetAllUsers` API is working successfully with new Key/Secret value.
- [x] Ensure that `GetUserDetails` is successful for a valid user.