### PR TITLE
Security modifications to Azure function deployment

### DIFF
--- a/deployment/azuredeploy.json
+++ b/deployment/azuredeploy.json
@@ -81,6 +81,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
+                "httpsOnly": true,
                 "siteConfig": {
                     "appSettings": [
                         {
@@ -124,7 +125,9 @@
                         "allowedOrigins": [
                             "[substring(reference(resourceId('Microsoft.Storage/storageAccounts/', variables('staticWebsite'))).primaryEndpoints.web,0,sub(length(reference(resourceId('Microsoft.Storage/storageAccounts/', variables('staticWebsite'))).primaryEndpoints.web),1))]"
                         ]
-                    }
+                    },
+                    "ftpsState": "Disabled",
+                    "minTlsVersion": "1.2"
                 },
                 "name": "[concat(variables('functionList')[copyIndex('FunctionatIndex')], variables('ProjectNameSuffix'))]",
                 "clientAffinityEnabled": false,


### PR DESCRIPTION
## Details
- Enforce HTTPS communication
- Enforce TLS1.2 communication
- Disable FTPS as we are not deploying FTP deployment

## Testing
- [x] Deploy the to ensure the above settings are reflected in Azure
- [x] Ensure that Learn-LTI based assignments function correctly with new changes
- [x] Ensure that `http` based communication moves to `https` by default