### PR TITLE
Soft delete and purge protection for Learn-LTI Key Vault

### DIFF
--- a/deployment/azuredeploy.json
+++ b/deployment/azuredeploy.json
@@ -378,6 +378,8 @@
                 "enabledForDeployment": "[variables('enabledForDeployment')]",
                 "enabledForDiskEncryption": "[variables('enabledForDiskEncryption')]",
                 "enabledForTemplateDeployment": "[variables('enabledForTemplateDeployment')]",
+                "enableSoftDelete": true,
+                "enablePurgeProtection": true,
                 "tenantId": "[variables('tenantId')]",
                 "accessPolicies": [
                     {


### PR DESCRIPTION
- Keeping the retention period to default (90 days).
- Added purge protection so that even on soft-deletion, the key cannot be removed from the subscription until the retention period ends.
- Tested with multiple deployments, as well as installing the tool in the LMS to verify the changes. 
- Also tried (soft) deleting the key, and then purging it from the subscription-- this gives a failure message, and therefore, serves our purpose. 