### PR TITLE
bugfix/case sensitive user email matching

### DIFF
--- a/backend/Bindings/Edna.Bindings.LtiAdvantage/Services/NrpsClient.cs
+++ b/backend/Bindings/Edna.Bindings.LtiAdvantage/Services/NrpsClient.cs
@@ -91,7 +91,7 @@ namespace Edna.Bindings.LtiAdvantage.Services
             // Looks like LTI 1.3 doesn't support querying by member identifiers
             IEnumerable<Member> allMembers = await Get(clientId, tokenUrl, membershipUrl);
 
-            return allMembers.FirstOrDefault(member => userEmails.Any(userEmail => (member.Email??String.Empty).Equals(userEmail)));
+            return allMembers.FirstOrDefault(member => userEmails.Any(userEmail => (member.Email??String.Empty).Equals(userEmail, StringComparison.OrdinalIgnoreCase)));
         }
 
         public async Task<Member> GetById(string clientId, string tokenUrl, string membershipUrl, string userId)


### PR DESCRIPTION
### Issue : 
[User emails - case sensitivity](https://github.com/microsoft/Learn-LTI/issues/114)

### RCA: 
The email matching happening in the NrpsClient.cs was case sensitive.
The String.Equals(string val) method performs an ordinal (case-sensitive and culture-insensitive) comparison.

### Solution:
Updated this check to String.Equals(string val, StringComparison comparisonType) with the comparison type set as OrdinalIgnoreCase

### Testing

Sanity check done with 2 LMSes