### PR TITLE
Add an error string when user is missing a name, prevents infinite spinner

### DIFF
--- a/client/src/Stores/Users.store.ts
+++ b/client/src/Stores/Users.store.ts
@@ -49,6 +49,8 @@ export class UsersStore extends ChildStore {
         this.errorContent = ErrorPageContent.CreateFromServiceError(user.error);
       } else if (!user) {
         this.errorContent = { errorMsg: 'You are not enrolled in this course.', icon: 'BlockContact' };
+      } else if (!user.givenName && !user.familyName) {
+        this.errorContent = { errorMsg: 'Please add a name for the user.', icon: 'BlockContact' };
       }
       return user;
     };


### PR DESCRIPTION
## Background
Fixes the blocker faced in **OpenEdx LTI Integration**, there the user does not have a name and the experience shows an un-ending `Loading` spinner on the screen.

@Lee - Would you please help with the appropriate string here? The case is that we would like the user to have a name to be shown on the screen. Without that, I've added an error instead for now.